### PR TITLE
Use phantomjs library instead of grunt-lib-phantomjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+.idea

--- a/lib/netsniff.js
+++ b/lib/netsniff.js
@@ -1,17 +1,3 @@
-if (!Date.prototype.toISOString) {
-    Date.prototype.toISOString = function () {
-        function pad(n) { return n < 10 ? '0' + n : n; }
-        function ms(n) { return n < 10 ? '00'+ n : n < 100 ? '0' + n : n }
-        return this.getFullYear() + '-' +
-            pad(this.getMonth() + 1) + '-' +
-            pad(this.getDate()) + 'T' +
-            pad(this.getHours()) + ':' +
-            pad(this.getMinutes()) + ':' +
-            pad(this.getSeconds()) + '.' +
-            ms(this.getMilliseconds()) + 'Z';
-    }
-}
-
 function createHAR(address, title, startTime, resources)
 {
     var entries = [];
@@ -96,11 +82,18 @@ function createHAR(address, title, startTime, resources)
 var page = require('webpage').create(),
     system = require('system');
 
+// FIXME: Ugly workaround for PhantomJS 1.9.8 bug:
+//        https://github.com/ariya/phantomjs/issues/12697#issuecomment-66914812
+function exit(code) {
+    if (page) page.close();
+    setTimeout(function(){ phantom.exit(code); }, 0);
+    phantom.onError = function(){};
+}
+
 if (system.args.length === 1) {
     console.log('Usage: netsniff.js <some URL>');
-    phantom.exit(1);
+    exit(1);
 } else {
-
     page.address = system.args[1];
     page.resources = [];
 
@@ -129,7 +122,7 @@ if (system.args.length === 1) {
         var har;
         if (status !== 'success') {
             console.log('FAIL to load the address');
-            phantom.exit(1);
+            exit(1);
         } else {
             page.endTime = new Date();
             page.title = page.evaluate(function () {
@@ -137,7 +130,7 @@ if (system.args.length === 1) {
             });
             har = createHAR(page.address, page.title, page.startTime, page.resources);
             console.log(JSON.stringify(har, undefined, 4));
-            phantom.exit();
+            exit();
         }
     });
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "pagespeed"
   ],
   "dependencies": {
+    "lodash": "^2.4.1",
     "grunt-lib-phantomjs": "~0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "pagespeed"
   ],
   "dependencies": {
+    "async": "^0.9.0",
     "lodash": "^2.4.1",
-    "grunt-lib-phantomjs": "~0.4.0"
+    "phantomjs": "^1.9.13"
   }
 }

--- a/tasks/har_gen.js
+++ b/tasks/har_gen.js
@@ -10,9 +10,9 @@
 
 module.exports = function(grunt) {
 
-  var exec = require('child_process').exec,
-      path = require('path'),
-      _ = grunt.util._,
+  var exec    = require('child_process').exec,
+      path    = require('path'),
+      _       = require('lodash'),
       script  = path.resolve(path.resolve(__dirname, 'lib/netsniff.js'));
 
   grunt.registerMultiTask('hargen', 'Grunt plugin for generating HAR files from a series of URLs', function() {

--- a/tasks/har_gen.js
+++ b/tasks/har_gen.js
@@ -8,47 +8,44 @@
 
 'use strict';
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
-  var exec    = require('child_process').exec,
-      path    = require('path'),
-      _       = require('lodash'),
-      script  = path.resolve(path.resolve(__dirname, 'lib/netsniff.js'));
+  var _ = require('lodash'),
+      async = require('async'),
+      exec = require('child_process').execFile,
+      path = require('path'),
+      phantomjs = require('phantomjs'),
+      asset = path.join.bind(null, __dirname, '..'),
+      netsniff = asset('lib/netsniff.js');
 
-  grunt.registerMultiTask('hargen', 'Grunt plugin for generating HAR files from a series of URLs', function() {
+  grunt.registerMultiTask('hargen', 'Grunt plugin for generating HAR files from a series of URLs', function () {
 
     var options = this.options({
-      urls: {},
-      output: './tmp'
-    }),
-    urls  = _.pairs(options.urls),
-    count = urls.length,
-    index = 0,
-    dir   = options.output,
-    done  = this.async();
+          urls:          {},
+          output:        './tmp'
+        }),
+        urls = _.pairs(options.urls),
+        dir = options.output,
+        done = this.async();
 
-    urls.forEach(function(pair) {
-      var filename = _.head(pair);
-      var url      = _.last(pair);
+    async.forEachSeries(urls, function (pair, next) {
+      var filename = pair[0],
+          url = pair[1];
 
-      var cmd = './node_modules/grunt-lib-phantomjs/node_modules/.bin/phantomjs ' + script + ' ' + url;
       grunt.log.writeln('Trying: ' + url);
 
-      var cp = exec(cmd, {maxBuffer: 1024 * 1024}, function (err, stdout, stderr) {
+      exec(phantomjs.path, [netsniff, url], {maxBuffer: 1024 * 1024}, function (err, stdout, stderr) {
         if (err) {
           grunt.log.errorlns('Failed to connect to: ' + url);
           grunt.verbose.writeln(stderr);
-        }else {
+        } else {
           grunt.log.writeln('Saving results to: ' + dir + '/' + filename);
           grunt.file.write(dir + '/' + filename, stdout);
         }
-        index++;
 
-        if (index === count) {
-          done();
-        }
+        next();
       });
-    });
+    }, done);
 
     if (0 === urls.length) {
       grunt.log.error('No urls specified');

--- a/tasks/har_gen.js
+++ b/tasks/har_gen.js
@@ -31,6 +31,8 @@ module.exports = function (grunt) {
           dir = options.output,
           done = this.async();
 
+      grunt.file.mkdir(dir);
+
       async.forEach(urls, function (pair, next) {
         var filename = pair[0],
             url = pair[1],

--- a/tasks/har_gen.js
+++ b/tasks/har_gen.js
@@ -24,7 +24,8 @@ module.exports = function (grunt) {
     function () {
       var options = this.options({
             urls:   {},
-            output: './tmp'
+            output: './tmp',
+            args: []
           }),
           urls = _.pairs(options.urls),
           dir = options.output,
@@ -32,11 +33,12 @@ module.exports = function (grunt) {
 
       async.forEach(urls, function (pair, next) {
         var filename = pair[0],
-            url = pair[1];
+            url = pair[1],
+            args = options.args.concat([netsniff, url]);
 
         grunt.log.writeln('Trying: ' + url);
 
-        var process = spawn(phantomjs.path, [netsniff, url], {
+        var process = spawn(phantomjs.path, args, {
           stdio: [
             'ignore',
             fs.openSync(dir + '/' + filename, 'w'),


### PR DESCRIPTION
Uses `phantomjs` library and uses it the recommended way instead of indirectly using the `phantom` binary inside `grunt-lib-phantomjs`. Apparently this project does not need the higher-level features of `grunt-lib-phantomjs` and this makes things easier and more robust (such as working on Windows etc.).
